### PR TITLE
Send event when device is paired/unpaired and update mDNS service reachability

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1,21 +1,20 @@
 package db
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
 
 func TestLoadUndefinedEntity(t *testing.T) {
-	db, _ := NewDatabase(os.TempDir())
+	db, _ := NewTempDatabase()
 
 	if _, err := db.EntityWithName("My Name"); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestLoadEntity(t *testing.T) {
-	db, _ := NewDatabase(os.TempDir())
+func TestGetEntity(t *testing.T) {
+	db, _ := NewTempDatabase()
 	db.SaveEntity(NewEntity("My Name", []byte{0x01}, []byte{0x02}))
 	var e Entity
 	var err error
@@ -33,8 +32,8 @@ func TestLoadEntity(t *testing.T) {
 	}
 }
 
-func TestLoadEntityWithPublicKeyOnly(t *testing.T) {
-	db, _ := NewDatabase(os.TempDir())
+func TestGetEntityWithPublicKeyOnly(t *testing.T) {
+	db, _ := NewTempDatabase()
 	db.SaveEntity(NewEntity("Entity", []byte{0x03}, nil))
 
 	var e Entity
@@ -54,11 +53,31 @@ func TestLoadEntityWithPublicKeyOnly(t *testing.T) {
 }
 
 func TestDeleteEntity(t *testing.T) {
-	db, _ := NewDatabase(os.TempDir())
+	db, _ := NewTempDatabase()
 	c := NewEntity("My Name", []byte{0x01}, nil)
 	db.SaveEntity(c)
 	db.DeleteEntity(c)
 	if _, err := db.EntityWithName("My Name"); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestGetEntities(t *testing.T) {
+	db, _ := NewTempDatabase()
+	e1 := NewEntity("Entity 1", []byte{0x01}, []byte{0x02})
+	e2 := NewEntity("Entity 2", []byte{0x01}, []byte{0x02})
+
+	db.SaveEntity(e1)
+	db.SaveEntity(e2)
+
+	var es []Entity
+	var err error
+
+	if es, err = db.Entities(); err != nil {
+		t.Fatal(err)
+	}
+
+	if x := es; reflect.DeepEqual(x, []Entity{e1, e2}) == false {
+		t.Fatal(x)
 	}
 }

--- a/event/constant.go
+++ b/event/constant.go
@@ -1,7 +1,7 @@
 package event
 
-// DevicePairingAdded is emitted when transport paired with a device (e.g. iOS client successfully paired with the accessory)
-type DevicePairingAdded struct{}
+// DevicePaired is emitted when transport paired with a device (e.g. iOS client successfully paired with the accessory)
+type DevicePaired struct{}
 
-// DevicePairingRemoved is emitted when pairing with a device is removed (e.g. iOS client removed the accessory from HomeKit)
-type DevicePairingRemoved struct{}
+// DeviceUnpaired is emitted when pairing with a device is removed (e.g. iOS client removed the accessory from HomeKit)
+type DeviceUnpaired struct{}

--- a/event/constant.go
+++ b/event/constant.go
@@ -1,0 +1,7 @@
+package event
+
+// DevicePairingAdded is emitted when transport paired with a device (e.g. iOS client successfully paired with the accessory)
+type DevicePairingAdded struct{}
+
+// DevicePairingRemoved is emitted when pairing with a device is removed (e.g. iOS client removed the accessory from HomeKit)
+type DevicePairingRemoved struct{}

--- a/event/event_emitter.go
+++ b/event/event_emitter.go
@@ -1,0 +1,32 @@
+package event
+
+// Emitter emits events to listeners
+type Emitter interface {
+
+	// Emit emits the event to all listeners
+	Emit(ev interface{})
+
+	// AddListener adds a listener to the event stream
+	AddListener(l EventListener)
+}
+
+type eventEmitter struct {
+	ls []EventListener
+}
+
+// NewEmitter returns a new event emitter
+func NewEmitter() Emitter {
+	return &eventEmitter{
+		ls: make([]EventListener, 0),
+	}
+}
+
+func (e *eventEmitter) Emit(ev interface{}) {
+	for _, l := range e.ls {
+		l.Handle(ev)
+	}
+}
+
+func (e *eventEmitter) AddListener(l EventListener) {
+	e.ls = append(e.ls, l)
+}

--- a/event/event_emitter_test.go
+++ b/event/event_emitter_test.go
@@ -1,0 +1,26 @@
+package event
+
+import (
+	"testing"
+)
+
+type testListener struct {
+	last interface{}
+}
+
+func (l *testListener) Handle(e interface{}) {
+	l.last = e
+}
+
+func TestEmitter(t *testing.T) {
+	e := NewEmitter()
+
+	l := &testListener{}
+	e.AddListener(l)
+
+	e.Emit(10)
+
+	if x := l.last; x != 10 {
+		t.Fatal(x)
+	}
+}

--- a/event/event_listener.go
+++ b/event/event_listener.go
@@ -1,0 +1,6 @@
+package event
+
+// EventListener handles events
+type EventListener interface {
+	Handle(e interface{})
+}

--- a/hap/mdns.go
+++ b/hap/mdns.go
@@ -21,7 +21,7 @@ type MDNSService struct {
 	configuration      int64 // c#
 	state              int64 // s#
 	mfiCompliant       bool  // ff
-	status             int64 // sf
+	reachable          bool  // sf
 	categoryIdentifier int64 // ci; default 1 (Other)
 
 	server *bonjour.Server
@@ -37,7 +37,7 @@ func NewMDNSService(name, id string, port int) *MDNSService {
 		configuration:      1,
 		state:              1,
 		mfiCompliant:       false,
-		status:             1,
+		reachable:          true,
 		categoryIdentifier: 1,
 	}
 }
@@ -45,6 +45,10 @@ func NewMDNSService(name, id string, port int) *MDNSService {
 // IsPublished returns true when the service is published.
 func (s *MDNSService) IsPublished() bool {
 	return s.server != nil
+}
+
+func (s *MDNSService) SetReachable(r bool) {
+	s.reachable = r
 }
 
 // Publish announces the service for the machine's ip address on a random port using mDNS.
@@ -107,7 +111,7 @@ func (s *MDNSService) txtRecords() []string {
 		fmt.Sprintf("id=%s", s.id),
 		fmt.Sprintf("c#=%d", s.configuration),
 		fmt.Sprintf("s#=%d", s.state),
-		fmt.Sprintf("sf=%d", s.status),
+		fmt.Sprintf("sf=%d", to.Int64(s.reachable)),
 		fmt.Sprintf("ff=%d", to.Int64(s.mfiCompliant)),
 		fmt.Sprintf("md=%s", s.name),
 		fmt.Sprintf("ci=%d", s.categoryIdentifier),

--- a/hap/mdns_test.go
+++ b/hap/mdns_test.go
@@ -21,3 +21,22 @@ func TestMDNS(t *testing.T) {
 		t.Fatal(expect)
 	}
 }
+
+func TestReachable(t *testing.T) {
+	mdns := NewMDNSService("My MDNS Service", "1234", 5010)
+	expect := []string{
+		"pv=1.0",
+		"id=1234",
+		"c#=1",
+		"s#=1",
+		"sf=0",
+		"ff=0",
+		"md=My MDNS Service",
+		"ci=1",
+	}
+	mdns.SetReachable(false)
+
+	if x := mdns.txtRecords(); reflect.DeepEqual(x, expect) == false {
+		t.Fatal(expect)
+	}
+}

--- a/netio/endpoint/pairings.go
+++ b/netio/endpoint/pairings.go
@@ -1,8 +1,10 @@
 package endpoint
 
 import (
+	"github.com/brutella/hc/event"
 	"github.com/brutella/hc/netio"
 	"github.com/brutella/hc/netio/pair"
+	"github.com/brutella/hc/util"
 	"github.com/brutella/log"
 	"io"
 	"net/http"
@@ -15,27 +17,46 @@ type Pairing struct {
 	http.Handler
 
 	controller *pair.PairingController
+	emitter    event.Emitter
 }
 
 // NewPairing returns a new handler for pairing enpdoint
-func NewPairing(controller *pair.PairingController) *Pairing {
-	handler := Pairing{
+func NewPairing(controller *pair.PairingController, emitter event.Emitter) *Pairing {
+	endpoint := Pairing{
 		controller: controller,
+		emitter:    emitter,
 	}
 
-	return &handler
+	return &endpoint
 }
 
-func (handler *Pairing) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+func (endpoint *Pairing) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 	log.Printf("[VERB] %v POST /pairings", request.RemoteAddr)
 	response.Header().Set("Content-Type", netio.HTTPContentTypePairingTLV8)
 
-	res, err := pair.HandleReaderForHandler(request.Body, handler.controller)
+	var err error
+	var in util.Container
+	var out util.Container
+
+	if in, err = util.NewTLV8ContainerFromReader(request.Body); err == nil {
+		out, err = endpoint.controller.Handle(in)
+	}
 
 	if err != nil {
 		log.Println(err)
 		response.WriteHeader(http.StatusInternalServerError)
 	} else {
-		io.Copy(response, res)
+		io.Copy(response, out.BytesBuffer())
+
+		// Send events based on pairing method type
+		b := in.GetByte(pair.TagPairingMethod)
+		switch pair.PairMethodType(b) {
+		case pair.PairingMethodDelete: // pairing removed
+			endpoint.emitter.Emit(event.DeviceUnpaired{})
+
+		case pair.PairingMethodAdd: // pairing added
+			endpoint.emitter.Emit(event.DevicePaired{})
+
+		}
 	}
 }

--- a/netio/handler.go
+++ b/netio/handler.go
@@ -16,7 +16,6 @@ type ContainerHandler interface {
 type PairVerifyHandler interface {
 	ContainerHandler
 	SharedKey() [32]byte
-	KeyVerified() bool
 }
 
 // A AccessoriesHandler returns a list of accessories as json.

--- a/netio/notification.go
+++ b/netio/notification.go
@@ -1,19 +1,17 @@
-// Package event implements event notifications used to notify clients when characteristic value changed.
-package event
+package netio
 
 import (
 	"bytes"
 	"encoding/json"
 	"github.com/brutella/hc/model/accessory"
 	"github.com/brutella/hc/model/characteristic"
-	"github.com/brutella/hc/netio"
 	"github.com/brutella/hc/netio/data"
 	"io/ioutil"
 	"net/http"
 	"strings"
 )
 
-// New returns an event response for a characteristic from an accessory.
+// New returns an notification response for a characteristic from an accessory.
 func New(a *accessory.Accessory, c *characteristic.Characteristic) (*http.Response, error) {
 	body, err := Body(a, c)
 	if err != nil {
@@ -28,7 +26,7 @@ func New(a *accessory.Accessory, c *characteristic.Characteristic) (*http.Respon
 	resp.Body = ioutil.NopCloser(body)
 	resp.ContentLength = int64(body.Len())
 	resp.Header = map[string][]string{}
-	resp.Header.Set("Content-Type", netio.HTTPContentTypeHAPJson)
+	resp.Header.Set("Content-Type", HTTPContentTypeHAPJson)
 	// (brutella) Not sure if Date header must be set
 	// resp.Header.Set("Date", netio.CurrentRFC1123Date())
 
@@ -47,7 +45,7 @@ func FixProtocolSpecifier(b []byte) []byte {
 	return []byte(strings.Replace(string(b), "HTTP/1.0", "EVENT/1.0", 1))
 }
 
-// Body returns the json body for an event response as bytes.
+// Body returns the json body for an notification response as bytes.
 func Body(a *accessory.Accessory, c *characteristic.Characteristic) (*bytes.Buffer, error) {
 	chars := data.NewCharacteristics()
 	char := data.Characteristic{AccessoryID: a.GetID(), ID: c.GetID(), Value: c.GetValue()}

--- a/netio/notification_test.go
+++ b/netio/notification_test.go
@@ -1,4 +1,4 @@
-package event
+package netio
 
 import (
 	"github.com/brutella/hc/model"

--- a/netio/pair/errors.go
+++ b/netio/pair/errors.go
@@ -7,15 +7,15 @@ import (
 
 var errInvalidClientKeyLength = errors.New("Invalid client public key size")
 
-var errInvalidPairMethod = func(m pairMethodType) error {
+var errInvalidPairMethod = func(m PairMethodType) error {
 	return fmt.Errorf("Invalid pairing method %v\n", m)
 }
 
-var errInvalidPairStep = func(t pairStepType) error {
+var errInvalidPairStep = func(t PairStepType) error {
 	return fmt.Errorf("Invalid pairing step %v\n", t)
 }
 
-var errInvalidInternalPairStep = func(t pairStepType) error {
+var errInvalidInternalPairStep = func(t PairStepType) error {
 	return fmt.Errorf("Invalid internal pairing step %v\n", t)
 }
 

--- a/netio/pair/method_types.go
+++ b/netio/pair/method_types.go
@@ -2,24 +2,24 @@ package pair
 
 import "fmt"
 
-type pairMethodType byte
+type PairMethodType byte
 
 const (
 	// PairingMethodDefault is the default pairing method.
-	PairingMethodDefault pairMethodType = 0x00
+	PairingMethodDefault PairMethodType = 0x00
 
 	// PairingMethodMFi is used to pair with an MFi compliant accessory (not used).
-	PairingMethodMFi pairMethodType = 0x01
+	PairingMethodMFi PairMethodType = 0x01
 
 	// PairingMethodAdd is used to pair a client by exchanging keys on a secured
 	// connection and without going through the pairing process.
-	PairingMethodAdd pairMethodType = 0x03
+	PairingMethodAdd PairMethodType = 0x03
 
 	// PairingMethodDelete is used to delete a pairing with a client.
-	PairingMethodDelete pairMethodType = 0x04
+	PairingMethodDelete PairMethodType = 0x04
 )
 
-func (m pairMethodType) String() string {
+func (m PairMethodType) String() string {
 	switch m {
 	case PairingMethodDefault:
 		return "Default"
@@ -33,6 +33,6 @@ func (m pairMethodType) String() string {
 	return fmt.Sprintf("%v Unknown", byte(m))
 }
 
-func (m pairMethodType) Byte() byte {
+func (m PairMethodType) Byte() byte {
 	return byte(m)
 }

--- a/netio/pair/pairing_controller.go
+++ b/netio/pair/pairing_controller.go
@@ -34,7 +34,7 @@ func NewPairingController(database db.Database) *PairingController {
 
 // Handle processes a container to pair with a new client without going through the pairing process.
 func (c *PairingController) Handle(cont util.Container) (util.Container, error) {
-	method := pairMethodType(cont.GetByte(TagPairingMethod))
+	method := PairMethodType(cont.GetByte(TagPairingMethod))
 	username := cont.GetString(TagUsername)
 	publicKey := cont.GetBytes(TagPublicKey)
 

--- a/netio/pair/sequence_types.go
+++ b/netio/pair/sequence_types.go
@@ -2,38 +2,38 @@ package pair
 
 import "fmt"
 
-// pairStepType defines the type of pairing steps.
-type pairStepType byte
+// PairStepType defines the type of pairing steps.
+type PairStepType byte
 
 const (
 	// PairStepWaiting is the step when waiting server waits for pairing request from a client.
-	PairStepWaiting pairStepType = 0x00
+	PairStepWaiting PairStepType = 0x00
 
 	// PairStepStartRequest sent from the client to the accessory to start pairing.
-	PairStepStartRequest pairStepType = 0x01
+	PairStepStartRequest PairStepType = 0x01
 
 	// PairStepStartResponse sent from the accessory to the client alongside the server's salt and public key
-	PairStepStartResponse pairStepType = 0x02
+	PairStepStartResponse PairStepType = 0x02
 
 	// PairStepVerifyRequest sent from the client to the accessory alongside the client public key and proof.
-	PairStepVerifyRequest pairStepType = 0x03
+	PairStepVerifyRequest PairStepType = 0x03
 
 	// PairStepVerifyResponse sent from the accessory to the client alongside the server's proof.
-	PairStepVerifyResponse pairStepType = 0x04
+	PairStepVerifyResponse PairStepType = 0x04
 
 	// PairStepKeyExchangeRequest sent from the client to the accessory alongside the client encrypted username and public key
-	PairStepKeyExchangeRequest pairStepType = 0x05
+	PairStepKeyExchangeRequest PairStepType = 0x05
 
 	// PairStepKeyExchangeResponse sent from the accessory to the client alongside the accessory encrypted username and public key
-	PairStepKeyExchangeResponse pairStepType = 0x06
+	PairStepKeyExchangeResponse PairStepType = 0x06
 )
 
 // Byte returns the raw byte value.
-func (t pairStepType) Byte() byte {
+func (t PairStepType) Byte() byte {
 	return byte(t)
 }
 
-func (t pairStepType) String() string {
+func (t PairStepType) String() string {
 	switch t {
 	case PairStepWaiting:
 		return "Waiting"

--- a/netio/pair/setup_client_controller.go
+++ b/netio/pair/setup_client_controller.go
@@ -45,7 +45,7 @@ func (setup *SetupClientController) InitialPairingRequest() io.Reader {
 
 // Handle processes a container to pair (exchange keys) with an accessory.
 func (setup *SetupClientController) Handle(in util.Container) (util.Container, error) {
-	method := pairMethodType(in.GetByte(TagPairingMethod))
+	method := PairMethodType(in.GetByte(TagPairingMethod))
 
 	// It is valid that method is not sent
 	// If method is sent then it must be 0x00
@@ -59,7 +59,7 @@ func (setup *SetupClientController) Handle(in util.Container) (util.Container, e
 		return nil, code.Error()
 	}
 
-	seq := pairStepType(in.GetByte(TagSequence))
+	seq := PairStepType(in.GetByte(TagSequence))
 
 	var out util.Container
 	var err error

--- a/netio/pair/setup_server_controller.go
+++ b/netio/pair/setup_server_controller.go
@@ -23,7 +23,7 @@ import (
 type SetupServerController struct {
 	device   netio.SecuredDevice
 	session  *SetupServerSession
-	step     pairStepType
+	step     PairStepType
 	database db.Database
 }
 
@@ -50,7 +50,7 @@ func NewSetupServerController(device netio.SecuredDevice, database db.Database) 
 
 // Handle processes a container to pair (exchange keys) with a client.
 func (setup *SetupServerController) Handle(in util.Container) (out util.Container, err error) {
-	method := pairMethodType(in.GetByte(TagPairingMethod))
+	method := PairMethodType(in.GetByte(TagPairingMethod))
 
 	// It is valid that pair method is not sent
 	// If method set then it must be 0x00
@@ -58,7 +58,7 @@ func (setup *SetupServerController) Handle(in util.Container) (out util.Containe
 		return nil, errInvalidPairMethod(method)
 	}
 
-	seq := pairStepType(in.GetByte(TagSequence))
+	seq := PairStepType(in.GetByte(TagSequence))
 
 	switch seq {
 	case PairStepStartRequest:
@@ -246,8 +246,6 @@ func (setup *SetupServerController) handleKeyExchange(in util.Container) (util.C
 			encrypted, mac, _ := chacha20poly1305.EncryptAndSeal(setup.session.EncryptionKey[:], []byte("PS-Msg06"), tlvPairKeyExchange.BytesBuffer().Bytes(), nil)
 			out.SetByte(TagSequence, PairStepKeyExchangeRequest.Byte())
 			out.SetBytes(TagEncryptedData, append(encrypted, mac[:]...))
-
-			setup.reset()
 		}
 	}
 

--- a/netio/pair/tag_types.go
+++ b/netio/pair/tag_types.go
@@ -2,7 +2,7 @@ package pair
 
 // These constants are used to access values in a TLV8 container.
 const (
-	// TagPairingMethod is the paring method tag. The value is of type pairMethodType.
+	// TagPairingMethod is the paring method tag. The value is of type PairMethodType.
 	TagPairingMethod = 0x00
 
 	// TagUsername is the username tag. The value is of type string.
@@ -20,7 +20,7 @@ const (
 	// TagEncryptedData is the encrypted data tag. The value includes the encrypted message and auth tag.
 	TagEncryptedData = 0x05
 
-	// TagSequence is the sequence tag. The value is of type pairStepType or VerifyStepType - depending on the context.
+	// TagSequence is the sequence tag. The value is of type PairStepType or VerifyStepType - depending on the context.
 	TagSequence = 0x06
 
 	// TagErrCode is the error tag. The value is of type ErrCode.

--- a/netio/pair/verify_client_controller.go
+++ b/netio/pair/verify_client_controller.go
@@ -40,7 +40,7 @@ func (verify *VerifyClientController) Handle(in util.Container) (util.Container,
 	var out util.Container
 	var err error
 
-	method := pairMethodType(in.GetByte(TagPairingMethod))
+	method := PairMethodType(in.GetByte(TagPairingMethod))
 
 	// It is valid that method is not sent
 	// If method is sent then it must be 0x00

--- a/netio/pair/verify_server_controller.go
+++ b/netio/pair/verify_server_controller.go
@@ -41,17 +41,12 @@ func (verify *VerifyServerController) SharedKey() [32]byte {
 	return verify.session.SharedKey
 }
 
-// KeyVerified returns true when key was successfully verified.
-func (verify *VerifyServerController) KeyVerified() bool {
-	return verify.step == VerifyStepFinishResponse
-}
-
 // Handle processes a container to verify if a client is paired correctly.
 func (verify *VerifyServerController) Handle(in util.Container) (util.Container, error) {
 	var out util.Container
 	var err error
 
-	method := pairMethodType(in.GetByte(TagPairingMethod))
+	method := PairMethodType(in.GetByte(TagPairingMethod))
 
 	// It is valid that method is not sent
 	// If method is sent then it must be 0x00

--- a/util/file_storage.go
+++ b/util/file_storage.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -73,6 +74,20 @@ func (f *fileStorage) Get(key string) ([]byte, error) {
 // Delete removes the file for the corresponding key.
 func (f *fileStorage) Delete(key string) error {
 	return os.Remove(f.filePathToFile(key))
+}
+
+func (f *fileStorage) KeysWithSuffix(suffix string) (keys []string, err error) {
+	var infos []os.FileInfo
+
+	if infos, err = ioutil.ReadDir(f.dir()); err == nil {
+		for _, info := range infos {
+			if info.IsDir() == false && strings.HasSuffix(info.Name(), suffix) == true {
+				keys = append(keys, info.Name())
+			}
+		}
+	}
+
+	return
 }
 
 // Private

--- a/util/file_storage_test.go
+++ b/util/file_storage_test.go
@@ -82,3 +82,24 @@ func TestGetUndefined(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestKeysWithSuffix(t *testing.T) {
+	var err error
+	var keys []string
+	storage, err := NewTempFileStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	storage.Set("test1.txt", []byte("ASDF"))
+	storage.Set("test2.txt", []byte("ASDF"))
+	storage.Set("test3.dat", []byte("ASDF"))
+
+	if keys, err = storage.KeysWithSuffix(".txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	if is, want := keys, []string{"test1.txt", "test2.txt"}; reflect.DeepEqual(is, want) == false {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+}

--- a/util/storage.go
+++ b/util/storage.go
@@ -10,4 +10,7 @@ type Storage interface {
 
 	// Get returns bytes for a key
 	Get(key string) ([]byte, error)
+
+	// KeysWithSuffix returns all keys with a specific suffix
+	KeysWithSuffix(suffix string) ([]string, error)
 }


### PR DESCRIPTION
The mDNS txt record entry `sf` indicates the reachability of the transport.
If a device is already paired with the transport, `sf` should be set to `0`.
iOS 9 checks for this flag and does not connect to the accessory if it still
set to `1`.

Now when a device is paired or unpaired, an event is send using an event emitter
and the mDNS txt records are updated.

This commit fixes #2.