### PR TITLE
Enable Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+sudo: false
+language: go

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HomeControl
 
+[![Build Status](https://travis-ci.org/brutella/hc.svg)](https://travis-ci.org/brutella/hc)
+
 [HomeControl][homecontrol] is an implementation of the [HomeKit][homekit] Accessory Protocol (HAP) to create your own HomeKit accessory and bridges. HomeKit bridges make non-HomeKit accessories available to HomeKit by acting as a middleman.
 
 ## Overview


### PR DESCRIPTION
`hc` has a lot of tests and it would be great to run them publicly on Travis CI, so that the test status is always visible.

This PR adds a basic `.travis.yml` file for Go. An example build (for my fork) can be fond here: https://travis-ci.org/mxlje/hc/builds/86285803

It also adds a **status badge** to the `README.md` under the assumption that the project will be available on Travis at `brutella/hc`, which is the same as on GitHub. If this will not be the case, let me know and I’ll update this accordingly.

@brutella All you have to do is enable the project in your Travis account. Once this is merged the build should start (and pass :tada:).

Thank you!