### PR TITLE
Add base dir for the storage interface so the directories do not get created at /

### DIFF
--- a/_example/example.go
+++ b/_example/example.go
@@ -14,7 +14,7 @@ func main() {
 		Name: "Lamp",
 	}
 	sw := accessory.NewSwitch(switchInfo)
-	t, err := hap.NewIPTransport("00102003", sw.Accessory)
+	t, err := hap.NewIPTransport("00102003", "tmp", sw.Accessory)
 
 	if err != nil {
 		log.Fatal(err)

--- a/hap/ip_transport.go
+++ b/hap/ip_transport.go
@@ -46,7 +46,7 @@ type ipTransport struct {
 // appears as a new one to clients.
 func NewIPTransport(pin string, pth string, a *accessory.Accessory, as ...*accessory.Accessory) (Transport, error) {
 	// Find transport name which is visible in mDNS
-	name := path.Join(pth, a.Name())
+	name := a.Name()
 	if len(name) == 0 {
 		log.Fatal("Invalid empty name for first accessory")
 	}
@@ -56,7 +56,7 @@ func NewIPTransport(pin string, pth string, a *accessory.Accessory, as ...*acces
 		return nil, err
 	}
 
-	storage, err := util.NewFileStorage(name)
+	storage, err := util.NewFileStorage(path.Join(pth, name))
 	if err != nil {
 		return nil, err
 	}

--- a/hap/ip_transport.go
+++ b/hap/ip_transport.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net"
+	"path"
 	"sync"
 
 	"github.com/brutella/hc/db"
@@ -43,9 +44,9 @@ type ipTransport struct {
 // So changing the order of the accessories or renaming the first accessory makes the stored
 // data inaccessible to the tranport. In this case new crypto keys are created and the accessory
 // appears as a new one to clients.
-func NewIPTransport(pin string, a *accessory.Accessory, as ...*accessory.Accessory) (Transport, error) {
+func NewIPTransport(pin string, pth string, a *accessory.Accessory, as ...*accessory.Accessory) (Transport, error) {
 	// Find transport name which is visible in mDNS
-	name := a.Name()
+	name := path.Join(pth, a.Name())
 	if len(name) == 0 {
 		log.Fatal("Invalid empty name for first accessory")
 	}


### PR DESCRIPTION
I have embedded this project in a web service of mine that I use to control hardware around my house (github.com/cswank/quimby).

When I start my web service with supervisor the storage directories get created at '/'.  You can pass in a "directory" arg to supervisor but when the web service is started from the command line for debugging then the directories get created in the current working directory.

This adds an arg to NewIPTransport that sets the directory where the storage directories get created.