### PR TITLE
Add Characteristic.OnValueGet hook

### DIFF
--- a/characteristic/bool.go
+++ b/characteristic/bool.go
@@ -25,6 +25,13 @@ func (c *Bool) GetValue() bool {
 	return c.Value.(bool)
 }
 
+// OnValueRemoteGet calls fn when the value was read by a client.
+func (c *Bool) OnValueRemoteGet(fn func() bool) {
+	c.OnValueGet(func() interface{} {
+		return fn()
+	})
+}
+
 // OnValueRemoteUpdate calls fn when the value was updated by a client.
 func (c *Bool) OnValueRemoteUpdate(fn func(bool)) {
 	c.OnValueUpdateFromConn(func(conn net.Conn, c *Characteristic, new, old interface{}) {

--- a/characteristic/characteristic_test.go
+++ b/characteristic/characteristic_test.go
@@ -5,6 +5,46 @@ import (
 	"testing"
 )
 
+func TestCharacteristicGetValue(t *testing.T) {
+	getCalls := 0
+	updateCalls := 0
+
+	c := NewCharacteristic(TypeOn)
+	c.Value = getCalls
+
+	c.OnValueUpdateFromConn(func(conn net.Conn, c *Characteristic, new, old interface{}) {
+		if conn != TestConn {
+			t.Fatal(conn)
+		}
+		updateCalls++
+	})
+
+	c.OnValueGet(func() interface{} {
+		getCalls++
+		return getCalls
+	})
+
+	if is, want := c.GetValue(), 1; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+
+	if is, want := updateCalls, 0; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+
+	if is, want := c.GetValueFromConnection(TestConn), 2; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+
+	if is, want := c.GetValueFromConnection(TestConn), 3; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+
+	if is, want := updateCalls, 2; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+}
+
 func TestCharacteristicUpdateValuesOfWrongType(t *testing.T) {
 	c := NewCharacteristic(TypeOn)
 	c.Value = 5

--- a/characteristic/float.go
+++ b/characteristic/float.go
@@ -47,6 +47,13 @@ func (c *Float) GetStepValue() float64 {
 	return c.StepValue.(float64)
 }
 
+// OnValueRemoteGet calls fn when the value was read by a client.
+func (c *Float) OnValueRemoteGet(fn func() float64) {
+	c.OnValueGet(func() interface{} {
+		return fn()
+	})
+}
+
 // OnValueRemoteUpdate calls fn when the value was updated by a client.
 func (c *Float) OnValueRemoteUpdate(fn func(float64)) {
 	c.OnValueUpdateFromConn(func(conn net.Conn, c *Characteristic, new, old interface{}) {

--- a/characteristic/int.go
+++ b/characteristic/int.go
@@ -47,6 +47,13 @@ func (c *Int) GetStepValue() int {
 	return c.StepValue.(int)
 }
 
+// OnValueRemoteGet calls fn when the value was read by a client.
+func (c *Int) OnValueRemoteGet(fn func() int) {
+	c.OnValueGet(func() interface{} {
+		return fn()
+	})
+}
+
 // OnValueRemoteUpdate calls fn when the value was updated by a client.
 func (c *Int) OnValueRemoteUpdate(fn func(int)) {
 	c.OnValueUpdateFromConn(func(conn net.Conn, c *Characteristic, new, old interface{}) {

--- a/characteristic/string.go
+++ b/characteristic/string.go
@@ -25,6 +25,13 @@ func (c *String) GetValue() string {
 	return c.Value.(string)
 }
 
+// OnValueRemoteGet calls fn when the value was read by a client.
+func (c *String) OnValueRemoteGet(fn func() string) {
+	c.OnValueGet(func() interface{} {
+		return fn()
+	})
+}
+
 // OnValueRemoteUpdate calls fn when the value was updated by a client.
 func (c *String) OnValueRemoteUpdate(fn func(string)) {
 	c.OnValueUpdateFromConn(func(conn net.Conn, c *Characteristic, new, old interface{}) {

--- a/hap/controller/characteristic_controller.go
+++ b/hap/controller/characteristic_controller.go
@@ -30,7 +30,7 @@ func NewCharacteristicController(m *accessory.Container) *CharacteristicControll
 }
 
 // HandleGetCharacteristics handles a get characteristic request like `/characteristics?id=1.4,1.5`
-func (ctr *CharacteristicController) HandleGetCharacteristics(form url.Values) (io.Reader, error) {
+func (ctr *CharacteristicController) HandleGetCharacteristics(form url.Values, conn net.Conn) (io.Reader, error) {
 	var b bytes.Buffer
 	var chs []data.Characteristic
 
@@ -42,7 +42,7 @@ func (ctr *CharacteristicController) HandleGetCharacteristics(form url.Values) (
 			iid := to.Int64(ids[1]) // instance id (= characteristic id)
 			c := data.Characteristic{AccessoryID: aid, CharacteristicID: iid}
 			if ch := ctr.GetCharacteristic(aid, iid); ch != nil {
-				c.Value = ch.Value
+				c.Value = ch.GetValueFromConnection(conn)
 			} else {
 				c.Status = hap.StatusServiceCommunicationFailure
 			}

--- a/hap/controller/characteristic_controller_test.go
+++ b/hap/controller/characteristic_controller_test.go
@@ -38,7 +38,7 @@ func TestGetCharacteristic(t *testing.T) {
 	cid := a.Info.Name.GetID()
 	values := idsString(aid, cid)
 	controller := NewCharacteristicController(m)
-	res, err := controller.HandleGetCharacteristics(values)
+	res, err := controller.HandleGetCharacteristics(values, characteristic.TestConn)
 
 	if err != nil {
 		t.Fatal(err)

--- a/hap/endpoint/characteristics.go
+++ b/hap/endpoint/characteristics.go
@@ -41,7 +41,9 @@ func (handler *Characteristics) ServeHTTP(response http.ResponseWriter, request 
 	case hap.MethodGET:
 		log.Debug.Printf("%v GET /characteristics", request.RemoteAddr)
 		request.ParseForm()
-		res, err = handler.controller.HandleGetCharacteristics(request.Form)
+		session := handler.context.GetSessionForRequest(request)
+		conn := session.Connection()
+		res, err = handler.controller.HandleGetCharacteristics(request.Form, conn)
 	case hap.MethodPUT:
 		log.Debug.Printf("%v PUT /characteristics", request.RemoteAddr)
 		session := handler.context.GetSessionForRequest(request)

--- a/hap/handler.go
+++ b/hap/handler.go
@@ -25,7 +25,7 @@ type AccessoriesHandler interface {
 
 // A CharacteristicsHandler handles get and update characteristic.
 type CharacteristicsHandler interface {
-	HandleGetCharacteristics(url.Values) (io.Reader, error)
+	HandleGetCharacteristics(url.Values, net.Conn) (io.Reader, error)
 	HandleUpdateCharacteristics(io.Reader, net.Conn) error
 }
 


### PR DESCRIPTION
This change proposes a characteristic hook that is invoked when `/characteristics` is accessed.

The is useful when the underlying accessory does not implement a change event system and must be polled. High frequency polling may also be excessive when the value is not changing all that often. Such a hook allows for a hybrid approach of low frequency polling and higher frequency checking when a user is actively engaging with the Home app.

```go
acc.Switch.On.OnValueGet(func() {
  // sync value check before responding
  fetchLatestSwitchValue()
})

acc.Switch.On.OnValueGet(func() {
  // or kick off an async value check between polling intervals
  go fetchLatestSwitchValue()
})
```

The [HAP-NodeJS](https://github.com/KhaosT/HAP-NodeJS) library offers a similar `getCharacteristic` hook.