### PR TITLE
accessory.Switch was using wrong type?

### DIFF
--- a/accessory/switch.go
+++ b/accessory/switch.go
@@ -12,7 +12,7 @@ type Switch struct {
 // NewSwitch returns a switch which implements model.Switch.
 func NewSwitch(info Info) *Switch {
 	acc := Switch{}
-	acc.Accessory = New(info, TypeOutlet)
+	acc.Accessory = New(info, TypeSwitch)
 	acc.Switch = service.NewSwitch()
 	acc.AddService(acc.Switch.Service)
 


### PR DESCRIPTION
Seemed to be a code copy error.