### PR TITLE
 Allow events to send the same event multiple times

### DIFF
--- a/characteristic/characteristic.go
+++ b/characteristic/characteristic.go
@@ -163,11 +163,6 @@ func (c *Characteristic) updateValue(value interface{}, conn net.Conn, checkPerm
 		value = c.boundIntValue(value.(int))
 	}
 
-	// Ignore when new value is same
-	if c.Value == value {
-		return
-	}
-
 	// Ignore new values from remote when permissions don't allow write and checkPerms is true
 	if checkPerms == true && c.hasWritePerms() == false {
 		return


### PR DESCRIPTION
The removed lines prevent an event to trigger a new event
when the previous triggered event has the same value.

E.g. When implementing a StatelessProgrammableSwitch, with these lines
in place, you can't trigger a single press twice. You first have to send
a double or long press before a single press can be triggered again.