### PR TITLE
Added support for go modules (go 1.11+)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/brutella/hc
+
+require (
+	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
+	github.com/brutella/dnssd v0.0.0-20180519095852-a1eecd10aafc
+	github.com/gosexy/to v0.0.0-20141221203644-c20e083e3123
+	github.com/miekg/dns v1.0.15 // indirect
+	github.com/tadglines/go-pkgs v0.0.0-20140924210655-1f86682992f1
+	golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85
+	golang.org/x/net v0.0.0-20181114220301-adae6a3d119a // indirect
+	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+github.com/brutella/dnssd v0.0.0-20180519095852-a1eecd10aafc h1:gevuvoeZlOfrFb7bfKeJWjYvkRMsDPyBHojp3wVy/yk=
+github.com/brutella/dnssd v0.0.0-20180519095852-a1eecd10aafc/go.mod h1:Gm5azbpU/tmPJNH9nQrFcTBIgasziqDdNYE/8epxvjc=
+github.com/gosexy/to v0.0.0-20141221203644-c20e083e3123 h1:6Q7VB4v0aEgIE6BtsbJhEH0KgFE0f+FHAxXePQp9Klc=
+github.com/gosexy/to v0.0.0-20141221203644-c20e083e3123/go.mod h1:oQuuq9ZkoRpy+2mhINlY3ZrwgywR77yPXmFpP6vCr/w=
+github.com/miekg/dns v1.0.15 h1:9+UupePBQCG6zf1q/bGmTO1vumoG13jsrbWOSX1W6Tw=
+github.com/miekg/dns v1.0.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/tadglines/go-pkgs v0.0.0-20140924210655-1f86682992f1 h1:ms/IQpkxq+t7hWpgKqCE5KjAUQWC24mqBrnL566SWgE=
+github.com/tadglines/go-pkgs v0.0.0-20140924210655-1f86682992f1/go.mod h1:roo6cZ/uqpwKMuvPG0YmzI5+AmUiMWfjCBZpGXqbTxE=
+golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85 h1:et7+NAX3lLIk5qUCTA9QelBjGE/NkhzYw/mhnr0s7nI=
+golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a h1:gOpx8G595UYyvj8UK4+OFyY4rx037g3fmfhe5SasG3U=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Added [Go Module](https://github.com/golang/go/wiki/Modules) support. This will not harm _exisisting_ users such as those still using `$GOPATH` or other dependency managers such as `go dep`.

Using the new go module's "replace" concept is a great way to develop code on other repositories locally without having to push to my own fork or use vendoring. I can simply maintain a fork, point to it locally (in my project's go.mod) by placing the following in my own `go.mod`:
```
module github.com/fernferret/my-proj

require (
	...
	github.com/brutella/hc v0.1.0
	...
)

replace github.com/brutella/hc v0.1.0 => /home/fernferret/projects/go/hc
```

but without a `go.mod` in `hc` you get the following error:

```
go: parsing ../hc/go.mod: open /home/fernferret/projects/go/hc/go.mod: no such file or directory
go: error loading module requirements
```

Also note: https://github.com/golang/go/wiki/Modules#should-i-commit-my-gosum-file-as-well-as-my-gomod-file

###  Notes on `go dep`
I realize there is an [Open PR](https://github.com/brutella/hc/pull/107) for [go dep](https://github.com/golang/dep) support, but from what I can tell go dep is still an evolving external standard. I don't see a huge reason to not support both (but I also don't use `go dep`, `go modules` give me everything I want, so maybe I'm biased)

### Notes on the `go mod`  commands to produce this PR (if you'd like to try it out):
```
$ go version
1.11+
$ cd /path/to/hc
$ unset GOPATH
$ go mod init github.com/brutella/hc
$ go get -v
```
That's it.