### PR TITLE
Custom Accessory IDs

### DIFF
--- a/accessory/accessory.go
+++ b/accessory/accessory.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Info struct {
+	ID               int64
 	Name             string
 	SerialNumber     string
 	Manufacturer     string
@@ -63,6 +64,7 @@ func New(info Info, typ AccessoryType) *Accessory {
 	}
 
 	acc := &Accessory{
+		ID:      info.ID,
 		idCount: 1,
 		Info:    svc,
 		Type:    typ,

--- a/accessory/container.go
+++ b/accessory/container.go
@@ -25,9 +25,10 @@ func NewContainer() *Container {
 // This method ensures that the accessory ids are valid and unique withing the container.
 func (m *Container) AddAccessory(a *Accessory) {
 	a.UpdateIDs()
-	a.ID = m.idCount
+	//a.ID = m.idCount
 	m.idCount++
 	m.Accessories = append(m.Accessories, a)
+	// FIX: verify that the ID is not a duplicate
 }
 
 // RemoveAccessory removes an accessory from the container.

--- a/accessory/container.go
+++ b/accessory/container.go
@@ -25,10 +25,28 @@ func NewContainer() *Container {
 // This method ensures that the accessory ids are valid and unique withing the container.
 func (m *Container) AddAccessory(a *Accessory) {
 	a.UpdateIDs()
-	//a.ID = m.idCount
-	m.idCount++
+	if a.ID == 0 {
+		// No ID set, use "next free"
+		a.ID = m.idCount
+		m.idCount++
+	} else {
+		if m.idCount <= a.ID {
+			m.idCount = a.ID + 1
+		}
+	}
+
+	// check against all existing accesories for duplicate IDs
+	for _, accessory := range m.Accessories {
+		if accessory.ID == a.ID {
+			// generate new id on collision
+			// midCount is allways the biggest unused ID
+			log.Info.Printf("Accesory ID %d is already in use, will use %d instead", a.ID, m.idCount)
+			a.ID = m.idCount
+			m.idCount++
+			break
+		}
+	}
 	m.Accessories = append(m.Accessories, a)
-	// FIX: verify that the ID is not a duplicate
 }
 
 // RemoveAccessory removes an accessory from the container.

--- a/accessory/container_test.go
+++ b/accessory/container_test.go
@@ -43,6 +43,48 @@ func TestContainer(t *testing.T) {
 	}
 }
 
+func TestContainerCustomID(t *testing.T) {
+	info1 := info
+	info1.ID = 99
+	info2 := info
+	info2.ID = 15
+	info3 := info
+	info3.ID = 15
+
+	acc1 := New(info1, TypeOther)
+	info2.Name = "Accessory2"
+	acc2 := New(info2, TypeOther)
+	info3.Name = "Accessory3"
+	acc3 := New(info3, TypeOther)
+
+	c := NewContainer()
+	c.AddAccessory(acc1)
+	c.AddAccessory(acc2)
+	c.AddAccessory(acc3)
+
+	if is, want := len(c.Accessories), 3; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+	if is, want := acc1.ID, int64(99); is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+	if is, want := acc2.ID, int64(15); is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+	if is, want := acc3.ID, int64(100); is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+	if acc2.ID == acc3.ID {
+		t.Fatal("equal ids not allowed")
+	}
+
+	c.RemoveAccessory(acc2)
+
+	if is, want := len(c.Accessories), 2; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+}
+
 func TestAccessoryCount(t *testing.T) {
 	accessory := New(info, TypeOther)
 	c := NewContainer()


### PR DESCRIPTION
This PR uses @bjanders implementation for custom accessory IDs (as mentioned in #146) and re-enables the automated enumeration to provide backwards compatibility.
Also I added a simple check against using an ID twice, which will then assign a new ID and prints an error message.

In general I would say it would be better to return an error in this case and not add the accessory. But this would change the function signature and might break some compatibility to existing applications. 

Also I'm not sure if we should handle the possible integer overflow here. It would be possible to generate ID collisions especially when mixing automatically generated IDs and custom IDs or duplicated custom IDs (which would also cause automatically generated IDs).

I made this PR as a first proof of concept and am open for any improvements/discussion.
