### PR TITLE
Support specifying accessory id

### DIFF
--- a/accessory/accessory.go
+++ b/accessory/accessory.go
@@ -10,6 +10,7 @@ type Info struct {
 	Manufacturer     string
 	Model            string
 	FirmwareRevision string
+	ID               uint64
 }
 
 // Accessory is a HomeKit accessory.
@@ -18,13 +19,13 @@ type Info struct {
 // Every accessory has the "accessory info" service by default which consists
 // of characteristics to identify the accessory: name, model, manufacturer,...
 type Accessory struct {
-	ID       int64              `json:"aid"`
+	ID       uint64             `json:"aid"`
 	Services []*service.Service `json:"services"`
 
 	Type AccessoryType                 `json:"-"`
 	Info *service.AccessoryInformation `json:"-"`
 
-	idCount    int64
+	idCount    uint64
 	onIdentify func()
 }
 
@@ -62,8 +63,14 @@ func New(info Info, typ AccessoryType) *Accessory {
 		svc.FirmwareRevision.SetValue("undefined")
 	}
 
+	var id uint64 = 0
+	if info.ID > id {
+		id = info.ID
+	}
+
 	acc := &Accessory{
 		idCount: 1,
+		ID:      id,
 		Info:    svc,
 		Type:    typ,
 	}

--- a/accessory/container_test.go
+++ b/accessory/container_test.go
@@ -20,8 +20,13 @@ func TestContainer(t *testing.T) {
 	acc2 := New(info, TypeOther)
 
 	c := NewContainer()
-	c.AddAccessory(acc1)
-	c.AddAccessory(acc2)
+	if err := c.AddAccessory(acc1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.AddAccessory(acc2); err != nil {
+		t.Fatal(err)
+	}
 
 	if is, want := len(c.Accessories), 2; is != want {
 		t.Fatalf("is=%v want=%v", is, want)
@@ -40,6 +45,20 @@ func TestContainer(t *testing.T) {
 
 	if is, want := len(c.Accessories), 1; is != want {
 		t.Fatalf("is=%v want=%v", is, want)
+	}
+}
+
+func TestDuplicateAccessoryId(t *testing.T) {
+	acc1 := New(Info{ID: 1}, TypeOther)
+	acc2 := New(Info{ID: 1}, TypeOther)
+
+	c := NewContainer()
+	if err := c.AddAccessory(acc1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.AddAccessory(acc2); err == nil {
+		t.Fatal("Error expected")
 	}
 }
 

--- a/characteristic/characteristic.go
+++ b/characteristic/characteristic.go
@@ -13,7 +13,7 @@ type GetFunc func() interface{}
 
 // Characteristic is a HomeKit characteristic.
 type Characteristic struct {
-	ID          int64    `json:"iid"` // managed by accessory
+	ID          uint64   `json:"iid"` // managed by accessory
 	Type        string   `json:"type"`
 	Perms       []string `json:"perms"`
 	Description string   `json:"description,omitempty"` // manufacturer description (optional)

--- a/hap/controller/characteristic_controller.go
+++ b/hap/controller/characteristic_controller.go
@@ -38,8 +38,8 @@ func (ctr *CharacteristicController) HandleGetCharacteristics(form url.Values, c
 	paths := strings.Split(form.Get("id"), ",")
 	for _, p := range paths {
 		if ids := strings.Split(p, "."); len(ids) == 2 {
-			aid := to.Int64(ids[0]) // accessory id
-			iid := to.Int64(ids[1]) // instance id (= characteristic id)
+			aid := to.Uint64(ids[0]) // accessory id
+			iid := to.Uint64(ids[1]) // instance id (= characteristic id)
 			c := data.Characteristic{AccessoryID: aid, CharacteristicID: iid}
 			if ch := ctr.GetCharacteristic(aid, iid); ch != nil {
 				c.Value = ch.GetValueFromConnection(conn)
@@ -95,7 +95,7 @@ func (ctr *CharacteristicController) HandleUpdateCharacteristics(r io.Reader, co
 }
 
 // GetCharacteristic returns the characteristic identified by the accessory id aid and characteristic id iid
-func (ctr *CharacteristicController) GetCharacteristic(aid int64, iid int64) *characteristic.Characteristic {
+func (ctr *CharacteristicController) GetCharacteristic(aid uint64, iid uint64) *characteristic.Characteristic {
 	for _, a := range ctr.container.Accessories {
 		if a.ID == aid {
 			for _, s := range a.GetServices() {

--- a/hap/controller/characteristic_controller_test.go
+++ b/hap/controller/characteristic_controller_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func idsString(accessoryID, characteristicID int64) url.Values {
+func idsString(accessoryID, characteristicID uint64) url.Values {
 	values := url.Values{}
 	values.Set("id", fmt.Sprintf("%d.%d", accessoryID, characteristicID))
 
@@ -82,7 +82,7 @@ func TestPutCharacteristic(t *testing.T) {
 	m.AddAccessory(a.Accessory)
 
 	// find on characteristic with type TypeOn
-	var cid int64
+	var cid uint64
 	for _, s := range a.Accessory.Services {
 		for _, c := range s.Characteristics {
 			if c.Type == characteristic.TypeOn {

--- a/hap/data/characteristics.go
+++ b/hap/data/characteristics.go
@@ -17,8 +17,8 @@ type Characteristics struct {
 //      "aid": 0, "iid": 1, "value": 10 [, "status": 0, "ev": true ]
 //  }
 type Characteristic struct {
-	AccessoryID      int64       `json:"aid"`
-	CharacteristicID int64       `json:"iid"`
+	AccessoryID      uint64      `json:"aid"`
+	CharacteristicID uint64      `json:"iid"`
 	Value            interface{} `json:"value"`
 
 	// Status contains the status code. Should be interpreted as integer.

--- a/service/service.go
+++ b/service/service.go
@@ -8,7 +8,7 @@ import (
 
 // Service is an HomeKit service consisting of characteristics.
 type Service struct {
-	ID              int64
+	ID              uint64
 	Type            string
 	Characteristics []*characteristic.Characteristic
 	Hidden          bool
@@ -66,16 +66,16 @@ func (s *Service) AddLinkedService(other *Service) {
 }
 
 type servicePayload struct {
-	ID              int64                            `json:"iid"`
+	ID              uint64                           `json:"iid"`
 	Type            string                           `json:"type"`
 	Characteristics []*characteristic.Characteristic `json:"characteristics"`
 	Hidden          *bool                            `json:"hidden,omitempty"`
 	Primary         *bool                            `json:"primary,omitempty"`
-	Linked          []int64                          `json:"linked,omitempty"`
+	Linked          []uint64                         `json:"linked,omitempty"`
 }
 
 func (s *Service) MarshalJSON() ([]byte, error) {
-	ids := []int64{}
+	ids := []uint64{}
 	for _, s := range s.Linked {
 		ids = append(ids, s.ID)
 	}


### PR DESCRIPTION
Once the accessory is paired with HomeKit, the accessory ids 
has to stay the same. HomeKit will mark the accessory as invalid
if the ids change. This commit also changes the id value type to uint64.

This fixes #146