### PR TITLE
Add enviroplus accessory

### DIFF
--- a/accessory/enviroplus.go
+++ b/accessory/enviroplus.go
@@ -1,17 +1,21 @@
 package accessory
 
 import (
+	"github.com/brutella/hc/characteristic"
 	"github.com/brutella/hc/service"
 )
 
+// EnviroPlus provides air quality, light and motion sensor readings
 type EnviroPlus struct {
 	*Accessory
 	TemperatureSensor *service.TemperatureSensor
-	HumiditySensor *service.HumiditySensor
-	AirQualitySensor *service.AirQualitySensor
-	LightSensor *service.LightSensor
+	HumiditySensor    *service.HumiditySensor
+	AirQualitySensor  *service.AirQualitySensor
+	LightSensor       *service.LightSensor
+	MotionSensor      *service.MotionSensor
 }
 
+// NewEnviroPlus returns an EnviroPlus accessory
 func NewEnviroPlus(info Info) *EnviroPlus {
 	acc := EnviroPlus{}
 	acc.Accessory = New(info, TypeSensor)
@@ -23,11 +27,21 @@ func NewEnviroPlus(info Info) *EnviroPlus {
 	acc.AddService(acc.HumiditySensor.Service)
 
 	acc.AirQualitySensor = service.NewAirQualitySensor()
+	pm25 := characteristic.NewPM2_5Density()
+	pm10 := characteristic.NewPM10Density()
+	carbonMonoxide := characteristic.NewCarbonMonoxideLevel()
+	nitrogenDioxide := characteristic.NewNitrogenDioxideDensity()
+	acc.AirQualitySensor.Service.AddCharacteristic(pm25.Characteristic)
+	acc.AirQualitySensor.Service.AddCharacteristic(pm10.Characteristic)
+	acc.AirQualitySensor.Service.AddCharacteristic(carbonMonoxide.Characteristic)
+	acc.AirQualitySensor.Service.AddCharacteristic(nitrogenDioxide.Characteristic)
 	acc.AddService(acc.AirQualitySensor.Service)
 
 	acc.LightSensor = service.NewLightSensor()
 	acc.AddService(acc.LightSensor.Service)
 
+	acc.MotionSensor = service.NewMotionSensor()
+	acc.AddService(acc.MotionSensor.Service)
+
 	return &acc
 }
-

--- a/accessory/enviroplus.go
+++ b/accessory/enviroplus.go
@@ -1,0 +1,33 @@
+package accessory
+
+import (
+	"github.com/brutella/hc/service"
+)
+
+type EnviroPlus struct {
+	*Accessory
+	TemperatureSensor *service.TemperatureSensor
+	HumiditySensor *service.HumiditySensor
+	AirQualitySensor *service.AirQualitySensor
+	LightSensor *service.LightSensor
+}
+
+func NewEnviroPlus(info Info) *EnviroPlus {
+	acc := EnviroPlus{}
+	acc.Accessory = New(info, TypeSensor)
+
+	acc.TemperatureSensor = service.NewTemperatureSensor()
+	acc.AddService(acc.TemperatureSensor.Service)
+
+	acc.HumiditySensor = service.NewHumiditySensor()
+	acc.AddService(acc.HumiditySensor.Service)
+
+	acc.AirQualitySensor = service.NewAirQualitySensor()
+	acc.AddService(acc.AirQualitySensor.Service)
+
+	acc.LightSensor = service.NewLightSensor()
+	acc.AddService(acc.LightSensor.Service)
+
+	return &acc
+}
+


### PR DESCRIPTION
Hi,

I'd like to add the [Pimoroni EnviroPlus](https://shop.pimoroni.com/products/enviro-plus), which is a combination of sensors:

* TemperatureSensor
* HumiditySensor
* AirQualitySensor
* LightSensor

Let me know if I'm missing anything in the PR.

Kind regards, Simon.

Related links:
* [hc Prometheus scraper](https://github.com/sighmon/homekit-enviroplus)
* [EnviroPlus Prometheus exporter](https://github.com/sighmon/balena-enviro-plus)