### PR TITLE
Add Accessory IDs found in the wild, requesting comments on new WiFi stuff

### DIFF
--- a/accessory/constant.go
+++ b/accessory/constant.go
@@ -20,6 +20,7 @@ const (
 	TypeWindow             AccessoryType = 13
 	TypeWindowCovering     AccessoryType = 14
 	TypeProgrammableSwitch AccessoryType = 15
+    TypeRangeExtender      AccessoryType = 16
 	TypeIPCamera           AccessoryType = 17
 	TypeVideoDoorbell      AccessoryType = 18
 	TypeAirPurifier        AccessoryType = 19
@@ -27,9 +28,16 @@ const (
 	TypeAirConditioner     AccessoryType = 21
 	TypeHumidifier         AccessoryType = 22
 	TypeDehumidifier       AccessoryType = 23
+    TypeAppleTV            AccessoryType = 24
+    TypeSpeaker            AccessoryType = 26
+    TypeAirport            AccessoryType = 27
 	TypeSprinklers         AccessoryType = 28
 	TypeFaucets            AccessoryType = 29
 	TypeShowerSystems      AccessoryType = 30
 	TypeTelevision         AccessoryType = 31
 	TypeRemoteControl      AccessoryType = 32
+    TypeWiFiRouter         AccessoryType = 33
+    TypeAudioReceiver      AccessoryType = 34
+    TypeTVSetTopBox        AccessoryType = 35
+    TypeTVStick            AccessoryType = 36
 )

--- a/accessory/constant.go
+++ b/accessory/constant.go
@@ -20,7 +20,7 @@ const (
 	TypeWindow             AccessoryType = 13
 	TypeWindowCovering     AccessoryType = 14
 	TypeProgrammableSwitch AccessoryType = 15
-    TypeRangeExtender      AccessoryType = 16
+	TypeRangeExtender      AccessoryType = 16
 	TypeIPCamera           AccessoryType = 17
 	TypeVideoDoorbell      AccessoryType = 18
 	TypeAirPurifier        AccessoryType = 19
@@ -28,16 +28,16 @@ const (
 	TypeAirConditioner     AccessoryType = 21
 	TypeHumidifier         AccessoryType = 22
 	TypeDehumidifier       AccessoryType = 23
-    TypeAppleTV            AccessoryType = 24
-    TypeSpeaker            AccessoryType = 26
-    TypeAirport            AccessoryType = 27
+	TypeAppleTV            AccessoryType = 24
+	TypeSpeaker            AccessoryType = 26
+	TypeAirport            AccessoryType = 27
 	TypeSprinklers         AccessoryType = 28
 	TypeFaucets            AccessoryType = 29
 	TypeShowerSystems      AccessoryType = 30
 	TypeTelevision         AccessoryType = 31
 	TypeRemoteControl      AccessoryType = 32
-    TypeWiFiRouter         AccessoryType = 33
-    TypeAudioReceiver      AccessoryType = 34
-    TypeTVSetTopBox        AccessoryType = 35
-    TypeTVStick            AccessoryType = 36
+	TypeWiFiRouter         AccessoryType = 33
+	TypeAudioReceiver      AccessoryType = 34
+	TypeTVSetTopBox        AccessoryType = 35
+	TypeTVStick            AccessoryType = 36
 )

--- a/characteristic/current_transport.go
+++ b/characteristic/current_transport.go
@@ -1,0 +1,20 @@
+package characteristic
+
+// CurrentTransport
+// this can't be right -- '0000021E-0000-1000-8000-0000022B'
+// const TypeWifiCurrentTransport = "21E"
+const TypeCurrentTransport = "22B"
+
+type CurrentTransport struct {
+	*Bool
+}
+
+func NewCurrentTransport() *CurrentTransport {
+	char := NewBool(TypeCurrentTransport)
+	char.Format = FormatBool
+	char.Perms = []string{PermRead}
+
+	char.SetValue(false)
+
+	return &CurrentTransport{char}
+}

--- a/characteristic/current_transport.go
+++ b/characteristic/current_transport.go
@@ -1,8 +1,5 @@
 package characteristic
 
-// CurrentTransport
-// this can't be right -- '0000021E-0000-1000-8000-0000022B'
-// const TypeWifiCurrentTransport = "21E"
 const TypeCurrentTransport = "22B"
 
 type CurrentTransport struct {

--- a/characteristic/wifi_capabilities.go
+++ b/characteristic/wifi_capabilities.go
@@ -1,11 +1,7 @@
 package characteristic
 
-// WifiCapabilities
-// this can't be right -- '0000021E-0000-1000-8000-0000022D'
-// const TypeWifiCapabilities = "21E"
-const TypeWifiCapabilities = "22D"
+const TypeWifiCapabilities = "22C"
 
-// I don't know what the various ints mean yet
 type WifiCapabilities = struct {
 	*Int
 }

--- a/characteristic/wifi_capabilities.go
+++ b/characteristic/wifi_capabilities.go
@@ -1,0 +1,20 @@
+package characteristic
+
+// WifiCapabilities
+// this can't be right -- '0000021E-0000-1000-8000-0000022D'
+// const TypeWifiCapabilities = "21E"
+const TypeWifiCapabilities = "22D"
+
+// I don't know what the various ints mean yet
+type WifiCapabilities = struct {
+	*Int
+}
+
+func NewWifiCapabilities() *WifiCapabilities {
+	char := NewInt(TypeWifiCapabilities)
+	char.Format = FormatUInt32
+	char.Perms = []string{PermRead}
+
+	char.SetValue(1)
+	return &WifiCapabilities{char}
+}

--- a/characteristic/wifi_configuration_control.go
+++ b/characteristic/wifi_configuration_control.go
@@ -1,0 +1,18 @@
+package characteristic
+
+// WifiConfigurationControl
+// this can't be right -- '0000021E-0000-1000-8000-0000022D'
+// const TypeWifiCapabilities = "21E"
+const TypeWifiConfigurationControl = "22D"
+
+type WifiConfigurationControl = struct {
+	*Bytes
+}
+
+func NewWifiConfigurationControl() *WifiConfigurationControl {
+	char := NewBytes(TypeWifiCapabilities)
+	char.Format = FormatTLV8
+	char.Perms = []string{PermRead, PermWrite, PermEvents}
+
+	return &WifiConfigurationControl{char}
+}

--- a/characteristic/wifi_configuration_control.go
+++ b/characteristic/wifi_configuration_control.go
@@ -1,8 +1,5 @@
 package characteristic
 
-// WifiConfigurationControl
-// this can't be right -- '0000021E-0000-1000-8000-0000022D'
-// const TypeWifiCapabilities = "21E"
 const TypeWifiConfigurationControl = "22D"
 
 type WifiConfigurationControl = struct {

--- a/service/wifitransport.go
+++ b/service/wifitransport.go
@@ -4,7 +4,7 @@ import (
 	"github.com/brutella/hc/characteristic"
 )
 
-const TypeWifiTransport = "203"
+const TypeWifiTransport = "22A"
 
 type WifiTransport struct {
 	*Service

--- a/service/wifitransport.go
+++ b/service/wifitransport.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"github.com/brutella/hc/characteristic"
+)
+
+const TypeWifiTransport = "203"
+
+type WifiTransport struct {
+	*Service
+
+	CurrentTransport         *characteristic.CurrentTransport
+	WifiCapabilities         *characteristic.WifiCapabilities
+	WifiConfigurationControl *characteristic.WifiConfigurationControl
+}
+
+func NewWifiTransport() *WifiTransport {
+	svc := WifiTransport{}
+	svc.Service = New(TypeWifiTransport)
+
+	svc.CurrentTransport = characteristic.NewCurrentTransport()
+	svc.AddCharacteristic(svc.CurrentTransport.Characteristic)
+
+	svc.WifiCapabilities = characteristic.NewWifiCapabilities()
+	svc.AddCharacteristic(svc.WifiCapabilities.Characteristic)
+
+	svc.WifiConfigurationControl = characteristic.NewWifiConfigurationControl()
+	svc.AddCharacteristic(svc.WifiConfigurationControl.Characteristic)
+
+	return &svc
+}


### PR DESCRIPTION
Found some values in ~/Library/HomeKit/plain-metadata.config

I'm trying to figure out the UUIDs for the WiFi stuff and can't seem to suss out what I need to do, any suggestions/pointers?