### PR TITLE
address data races

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ os:
   - osx
 dist: trusty
 install: true
+script: go test -race -v ./...

--- a/characteristic/characteristic_test.go
+++ b/characteristic/characteristic_test.go
@@ -155,7 +155,7 @@ func TestCharacteristicRemoteDelegate(t *testing.T) {
 	}
 }
 
-func TestValueChangeNoUPdate(t *testing.T) {
+func TestValueChangeNoUpdate(t *testing.T) {
 	c := NewOn()
 	c.Value = true
 

--- a/characteristic/characteristic_test.go
+++ b/characteristic/characteristic_test.go
@@ -2,8 +2,46 @@ package characteristic
 
 import (
 	"net"
+	"sync"
 	"testing"
 )
+
+func TestCharacteristic_UpdateGetValue_DataRace(t *testing.T) {
+	c := NewCharacteristic(TypeBrightness)
+	c.Perms = []string{PermRead, PermWrite}
+
+	c.Value = 0
+	newValue := 1
+
+	wg := sync.WaitGroup{}
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		c.UpdateValue(newValue)
+	}()
+
+	go func() {
+		defer wg.Done()
+		c.UpdateValueFromConnection(newValue, TestConn)
+	}()
+
+	go func() {
+		defer wg.Done()
+		if is, want := c.GetValue(), 1; is != want {
+			t.Fatalf("is=%d, want=%d", is, want)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if is, want := c.GetValueFromConnection(TestConn), 1; is != want {
+			t.Fatalf("is=%d, want=%d", is, want)
+		}
+	}()
+
+	wg.Wait()
+}
 
 func TestCharacteristicGetValue(t *testing.T) {
 	getCalls := 0

--- a/crypto/secure_session.go
+++ b/crypto/secure_session.go
@@ -7,6 +7,7 @@ import (
 	"github.com/brutella/hc/crypto/chacha20poly1305"
 	"github.com/brutella/hc/crypto/hkdf"
 	"io"
+	"sync/atomic"
 )
 
 // secureSession provide a secure session by encrypting and decrypting data
@@ -68,8 +69,7 @@ func (s *secureSession) Encrypt(r io.Reader) (io.Reader, error) {
 	var buf bytes.Buffer
 	for _, p := range packets {
 		var nonce [8]byte
-		binary.LittleEndian.PutUint64(nonce[:], s.encryptCount)
-		s.encryptCount++
+		binary.LittleEndian.PutUint64(nonce[:], atomic.AddUint64(&s.encryptCount, 1)-1)
 
 		bLength := make([]byte, 2)
 		binary.LittleEndian.PutUint16(bLength, uint16(p.length))
@@ -114,8 +114,7 @@ func (s *secureSession) Decrypt(r io.Reader) (io.Reader, error) {
 		}
 
 		var nonce [8]byte
-		binary.LittleEndian.PutUint64(nonce[:], s.decryptCount)
-		s.decryptCount++
+		binary.LittleEndian.PutUint64(nonce[:], atomic.AddUint64(&s.decryptCount, 1)-1)
 
 		lengthBytes := make([]byte, 2)
 		binary.LittleEndian.PutUint16(lengthBytes, uint16(length))

--- a/crypto/secure_session_test.go
+++ b/crypto/secure_session_test.go
@@ -17,6 +17,10 @@ func TestCrypto(t *testing.T) {
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	server, err := NewSecureSessionFromSharedKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	client, err := NewSecureClientSessionFromSharedKey(key)
 	if err != nil {
 		t.Fatal(err)
@@ -64,6 +68,10 @@ func TestCryptoMaxPacketCount(t *testing.T) {
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	server, err := NewSecureSessionFromSharedKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	client, err := NewSecureClientSessionFromSharedKey(key)
 	if err != nil {
 		t.Fatal(err)
@@ -114,6 +122,10 @@ func TestCryptoMaxPacketLength(t *testing.T) {
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	server, err := NewSecureSessionFromSharedKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	client, err := NewSecureClientSessionFromSharedKey(key)
 	if err != nil {
 		t.Fatal(err)

--- a/crypto/secure_session_test.go
+++ b/crypto/secure_session_test.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"reflect"
@@ -21,30 +22,37 @@ func TestCrypto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var b bytes.Buffer
-	b.Write(data)
-
 	// Set count to min 2 bytes to test byte order handling
 	secServer := server.(*secureSession)
 	secServer.encryptCount = 128
-	encrypted, err := server.Encrypt(&b)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	secClient := client.(*secureSession)
 	secClient.decryptCount = 128
-	decrypted, err := client.Decrypt(encrypted)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	orig, err := ioutil.ReadAll(decrypted)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reflect.DeepEqual(orig, data) == false {
-		t.Fatal("invalid decryption")
+	for i := 0; i < 2; i++ {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			t.Parallel()
+			var b bytes.Buffer
+			b.Write(data)
+
+			encrypted, err := server.Encrypt(&b)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			decrypted, err := client.Decrypt(encrypted)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			orig, err := ioutil.ReadAll(decrypted)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if reflect.DeepEqual(orig, data) == false {
+				t.Fatal("invalid decryption")
+			}
+		})
 	}
 }
 

--- a/hap/fakes_test.go
+++ b/hap/fakes_test.go
@@ -1,0 +1,74 @@
+package hap
+
+import (
+	"github.com/brutella/hc/util"
+	"io"
+	"net"
+	"time"
+)
+
+var testConn net.Conn = &fakeConn{}
+
+type fakeConn struct {
+}
+
+func (f *fakeConn) Read(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (f *fakeConn) Write(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (f *fakeConn) Close() error {
+	return nil
+}
+
+func (f *fakeConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (f *fakeConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (f *fakeConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (f *fakeConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (f *fakeConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+type fakeCryptographer struct {
+}
+
+func (f fakeCryptographer) Encrypt(r io.Reader) (io.Reader, error) {
+	return nil, nil
+}
+
+func (f fakeCryptographer) Decrypt(r io.Reader) (io.Reader, error) {
+	return nil, nil
+}
+
+type fakeContainerHandler struct {
+}
+
+func (f fakeContainerHandler) Handle(container util.Container) (util.Container, error) {
+	return nil, nil
+}
+
+type fakePairVerifyHandler struct {
+}
+
+func (p fakePairVerifyHandler) Handle(container util.Container) (util.Container, error) {
+	return nil, nil
+}
+
+func (p fakePairVerifyHandler) SharedKey() [32]byte {
+	return [32]byte{}
+}

--- a/hap/session_test.go
+++ b/hap/session_test.go
@@ -1,0 +1,60 @@
+package hap
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSession_DataRace(t *testing.T) {
+	session := NewSession(testConn)
+
+	cryptographer := &fakeCryptographer{}
+	pairSetupHandler := &fakeContainerHandler{}
+	pairVerifyHandler := &fakePairVerifyHandler{}
+
+	wg := sync.WaitGroup{}
+	wg.Add(7)
+
+	go func() {
+		defer wg.Done()
+		session.SetCryptographer(cryptographer)
+	}()
+
+	go func() {
+		defer wg.Done()
+		if is, want := session.Decrypter(), cryptographer; is != want {
+			t.Fatalf("is = %v, want = %v", is, want)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		session.Encrypter()
+	}()
+
+	go func() {
+		defer wg.Done()
+		session.SetPairSetupHandler(pairSetupHandler)
+	}()
+
+	go func() {
+		defer wg.Done()
+		if is, want := session.PairSetupHandler(), pairSetupHandler; is != want {
+			t.Fatalf("is = %v, want = %v", is, want)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		session.SetPairVerifyHandler(pairVerifyHandler)
+	}()
+
+	go func() {
+		defer wg.Done()
+		if is, want := session.PairVerifyHandler(), pairVerifyHandler; is != want {
+			t.Fatalf("is = %v, want = %v", is, want)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/rtp/stream_configuration_test.go
+++ b/rtp/stream_configuration_test.go
@@ -1,7 +1,6 @@
 package rtp
 
 import (
-	"fmt"
 	"github.com/brutella/hc/characteristic"
 	"github.com/brutella/hc/tlv8"
 	"testing"
@@ -18,6 +17,4 @@ func TestSelectedStreamConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fmt.Printf("%+v", cfg)
 }


### PR DESCRIPTION
there are some data races that can be spotted by running `_example/example` with `-race`, especially after changing the sleep interval to <1s.

to note: the data race in `Characteristic`'s `updateValue`/`getValue` probably needs a better solution, maybe some refactoring, than just using locks:

- calling `SetValue` or `GetValue` inside `OnValueRemoteUpdate` now locks forever (but i'm not sure if it actually makes sense to do so in the first place)
- it's still possible to cause a data race by reading and writing to the `Value` field directly
