### PR TITLE
Fix type name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Once the bridge was added, the other accessories appear automatically.
 HomeKit requires that every accessory has a unique id, which must not change between system restarts.
 `hc` automatically assigns the ids for you based on the order in which the accessories are added to the bridge.
 
-But I recommend that you specify the accessory id yourself, via the [accessory.Config.ID](https://github.com/brutella/hc/blob/master/accessory/accessory.go#L13) field, like this.
+But I recommend that you specify the accessory id yourself, via the [accessory.Info.ID](https://github.com/brutella/hc/blob/master/accessory/accessory.go#L13) field, like this.
 
 ```go
 bridge := accessory.NewBridge(accessory.Info{Name: "Bridge", ID: 1})


### PR DESCRIPTION
This PR changes the `accessory.Config` to `accessory.Info` in the readme.