### PR TITLE
Add "Valid Values" and "Valid Value Range" characteristic objects

### DIFF
--- a/characteristic/characteristic.go
+++ b/characteristic/characteristic.go
@@ -22,10 +22,12 @@ type Characteristic struct {
 	Format string      `json:"format"`
 	Unit   string      `json:"unit,omitempty"`
 
-	MaxLen    int         `json:"maxLen,omitempty"`
-	MaxValue  interface{} `json:"maxValue,omitempty"`
-	MinValue  interface{} `json:"minValue,omitempty"`
-	StepValue interface{} `json:"minStep,omitempty"`
+	MaxLen           int         `json:"maxLen,omitempty"`
+	MaxValue         interface{} `json:"maxValue,omitempty"`
+	MinValue         interface{} `json:"minValue,omitempty"`
+	StepValue        interface{} `json:"minStep,omitempty"`
+	ValidValues      interface{} `json:"valid-values,omitempty"`
+	ValidValuesRange interface{} `json:"valid-values-range,omitempty"`
 
 	// unused
 	Events bool `json:"-"`
@@ -177,6 +179,23 @@ func (c *Characteristic) clampFloat(value float64) interface{} {
 func (c *Characteristic) clampInt(value int) interface{} {
 	min, minOK := c.MinValue.(int)
 	max, maxOK := c.MaxValue.(int)
+	validValues, validValuesOK := c.ValidValues.([]int)
+	validValuesRange, validValuesRangeOK := c.ValidValuesRange.([]int)
+
+	if validValuesOK == true && len(validValues) > 0 {
+		for _, valid := range validValues {
+			if value == valid {
+				return value
+			}
+		}
+		return validValues[0] // Invalid, clamp to the first valid value
+	}
+
+	if validValuesRangeOK == true {
+		min, minOK = validValuesRange[0], true
+		max, maxOK = validValuesRange[1], true
+	}
+
 	if maxOK == true && value > max {
 		value = max
 	} else if minOK == true && value < min {

--- a/characteristic/int.go
+++ b/characteristic/int.go
@@ -30,6 +30,14 @@ func (c *Int) SetStepValue(value int) {
 	c.StepValue = value
 }
 
+func (c *Int) SetValidValues(values []int) {
+	c.ValidValues = values
+}
+
+func (c *Int) SetValidValuesRange(start int, end int) {
+	c.ValidValuesRange = []int{start, end}
+}
+
 // GetValue returns the value as int
 func (c *Int) GetValue() int {
 	return c.Characteristic.GetValue().(int)
@@ -45,6 +53,14 @@ func (c *Int) GetMaxValue() int {
 
 func (c *Int) GetStepValue() int {
 	return c.StepValue.(int)
+}
+
+func (c *Int) GetValidValues() []int {
+	return c.ValidValues.([]int)
+}
+
+func (c *Int) GetValidValuesRange() (int, int) {
+	return c.ValidValues.([]int)[0], c.ValidValues.([]int)[1]
 }
 
 // OnValueRemoteGet calls fn when the value was read by a client.

--- a/characteristic/int_test.go
+++ b/characteristic/int_test.go
@@ -16,3 +16,35 @@ func TestNumberIntOutOfBounds(t *testing.T) {
 		t.Fatalf("is=%v want=%v", is, want)
 	}
 }
+
+func TestNumberIntOutOfValidValues(t *testing.T) {
+	number := NewInt("")
+	number.Format = FormatUInt8
+	number.Perms = PermsAll()
+	number.SetValidValues([]int{
+		0,
+		10,
+	})
+
+	number.SetValue(5)
+	if is, want := number.GetValue(), 0; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+}
+
+func TestNumberIntOutOfValidValuesRange(t *testing.T) {
+	number := NewInt("")
+	number.Format = FormatUInt8
+	number.Perms = PermsAll()
+	number.SetValidValuesRange(0, 100)
+
+	number.SetValue(120)
+	if is, want := number.GetValue(), 100; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+
+	number.SetValue(-40)
+	if is, want := number.GetValue(), 0; is != want {
+		t.Fatalf("is=%v want=%v", is, want)
+	}
+}


### PR DESCRIPTION
As described in "6.3.3 Characteristic Objects" section of the HAP Specification.

This is required for characteristics that are enumeration values and when a service doesn't support all the possible enumeration values.

This has been tested with the following code (for which it was required) with an iOS client and results in the expected behavior:

```Go
ss := service.NewSecuritySystem()
ss.SecuritySystemCurrentState.SetValidValues([]int{
	characteristic.SecuritySystemCurrentStateDisarmed,
	characteristic.SecuritySystemCurrentStateAwayArm,
	characteristic.SecuritySystemCurrentStateAlarmTriggered,
})
ss.SecuritySystemTargetState.SetValidValues([]int{
	characteristic.SecuritySystemTargetStateDisarm,
	characteristic.SecuritySystemTargetStateAwayArm,
})
```

This descriptor should only be used for `UInt8` and for Apple-defined characteristics, but this is not enforced in this PR.